### PR TITLE
feat(server): add registration endpoint

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,15 +3,17 @@ import { Elysia } from "elysia";
 import { RequireBase } from "./middlewares/base.js";
 import { RequireErrorFallback } from "./middlewares/fallback.js";
 import { LoginRoute } from "./routes/login.js";
+import { RegisterRoute } from "./routes/register.js";
 
 const app = new Elysia()
-	.use(RequireBase)
-	// Public
-	.use(LoginRoute)
-	// Private
-	//
-	.use(RequireErrorFallback)
-	.listen(process.env.PORT || 8080);
+        .use(RequireBase)
+        // Public
+        .use(LoginRoute)
+        .use(RegisterRoute)
+        // Private
+        //
+        .use(RequireErrorFallback)
+        .listen(process.env.PORT || 8080);
 
 console.log(
 	`🏠 Pronajemik API is running at http://${app.server?.hostname}:${app.server?.port}`,

--- a/packages/server/src/routes/register.ts
+++ b/packages/server/src/routes/register.ts
@@ -1,0 +1,24 @@
+import { Elysia, t } from "elysia";
+
+import { RequireBase } from "../middlewares/base";
+import { failure, type RouteResponse, success } from "../services/response";
+import { registerUser } from "../services/user";
+
+export const RegisterRoute = new Elysia({ name: "Route.Register" })
+        .use(RequireBase)
+        .post(
+                "/register",
+                async ({ database, body }): RouteResponse<null> => {
+                        const userId = await registerUser({ database, ...body });
+                        if (!userId) {
+                                return failure("Registration failed");
+                        }
+                        return success(null);
+                },
+                {
+                        body: t.Object({
+                                login: t.String(),
+                                password: t.String(),
+                        }),
+                },
+        );

--- a/packages/server/src/services/user.ts
+++ b/packages/server/src/services/user.ts
@@ -7,13 +7,19 @@ export type User = {
 };
 
 export type LoginUserArgs = {
-	database: Database;
-	login: string;
-	password: string;
+        database: Database;
+        login: string;
+        password: string;
+};
+
+export type RegisterUserArgs = {
+       database: Database;
+       login: string;
+       password: string;
 };
 
 export async function loginUser(args: LoginUserArgs) {
-	const { database, login, password } = args;
+        const { database, login, password } = args;
 
 	const user = await database.users.findOne({ user: login });
 	if (!user) {
@@ -25,7 +31,19 @@ export async function loginUser(args: LoginUserArgs) {
 		return null;
 	}
 
-	return user._id.toString();
+        return user._id.toString();
+}
+
+export async function registerUser(args: RegisterUserArgs) {
+       const { database, login, password } = args;
+
+       const existing = await database.users.findOne({ user: login });
+       if (existing) {
+               return null;
+       }
+
+       const result = await database.users.insertOne({ user: login, password });
+       return result.insertedId.toString();
 }
 
 export type GetUserArgs = {


### PR DESCRIPTION
## Summary
- add `RegisterRoute` to expose POST `/register`
- implement `registerUser` service for creating new users
- wire registration route in server

## Testing
- `bun run format` *(fails: biome command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d942061483228b20ea49d9cf7b95